### PR TITLE
Remove redundant inline optimizer listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,12 +215,5 @@
 
 <!-- heat-map (requiere Plotly + stats + dataService ya cargados) -->
 <script type="module" src="js/heatmap.js"></script>
-<script type="module">
-  document.getElementById('btn-optimize')
-          .addEventListener('click', () => {
-            import('./js/optimizer.js')
-              .then(m => m.runOptimization());
-          });
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove inline script that duplicated click handler for optimizer

## Testing
- `npm test` *(fails: no `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845eb433a788320a6853c83a411eed4