### PR TITLE
Add asset allocation display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -148,12 +148,28 @@ body{
             font-weight: bold;
         }
 
-        .metrics-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); /* Reducido */
-            gap: 10px; /* Reducido */
-            margin-bottom: 15px; /* Reducido */
-        }
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); /* Reducido */
+    gap: 10px; /* Reducido */
+    margin-bottom: 15px; /* Reducido */
+}
+
+/* Tabla con asignaciones monetarias */
+.allocation-table {
+    margin-top: 10px;
+    font-size: 0.85rem;
+}
+.allocation-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.allocation-table td {
+    padding: 2px 4px;
+}
+.allocation-table tr:nth-child(even) {
+    background-color: #1E2128;
+}
 
         .metric-card {
             background-color: #1E2128;

--- a/index.html
+++ b/index.html
@@ -158,9 +158,10 @@
 
                 <div class="right-column">
                     <h3>Distribución Óptima</h3>
-                    <div class="doughnut-placeholder" id="portfolio-weights-chart" style="width: 200px; height: 200px;"> 
+                    <div class="doughnut-placeholder" id="portfolio-weights-chart" style="width: 200px; height: 200px;">
                         Pesos (Doughnut)
                     </div>
+                    <div id="allocation-container" class="allocation-table"></div>
 
                     <h3 style="margin-top: 15px;">Métricas Clave:</h3>
                     <div class="metrics-grid">

--- a/js/optimizer.js
+++ b/js/optimizer.js
@@ -5,6 +5,7 @@
 import store             from './store.js';
 import { loadPricesFor } from './dataService.js';
 import { logReturns, mean, covariance } from './stats.js';
+import { showToast }     from './main.js';
 
 /* Config */
 const N_PORTFOLIOS = 5000;
@@ -91,6 +92,22 @@ export async function runOptimization () {
   const choice  = subset.length
     ? subset.reduce((a,b)=> b.sharpe > a.sharpe ? b : a)
     : best;
+
+  /* 5.c Calcular asignaciones en moneda ------------------------------- */
+  const allocBox = document.getElementById('allocation-container');
+  const invInput = document.getElementById('investment-amount');
+  const capital  = invInput ? +invInput.value : 0;
+  if (!isFinite(capital) || capital <= 0) {
+    allocBox && (allocBox.innerHTML = '');
+    if (invInput && invInput.value) {
+      showToast('Ingrese un monto de inversión válido', 'warning');
+    }
+  } else if (allocBox) {
+    const rows = tickers.map((t, i) =>
+      `<tr><td>${t}</td><td>${(capital * choice.w[i]).toFixed(2)}</td></tr>`
+    ).join('');
+    allocBox.innerHTML = `<table class="alloc-table"><tbody>${rows}</tbody></table>`;
+  }
 
   /* 6. Scatter + estrellita ---------------------------------------------- */
   const scat = {


### PR DESCRIPTION
## Summary
- compute currency allocation per asset after optimization
- show a table of allocations below the doughnut chart
- style new allocation table

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ed18c2348320a7c769ce7c935231