### PR TITLE
Add UI parameter listeners

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@
  ─────────────────────────────────────────── */
 
 import { fetchRiskFree } from './dataService.js';
+import store from './store.js';
 
 /* ---------- Estado ----------- */
 let currentStep = 1;
@@ -39,6 +40,28 @@ document.addEventListener('DOMContentLoaded', () => {
   // El botón Optimizar importa optimizer.js dinámicamente
   document.getElementById('btn-optimize').addEventListener('click', () => {
     import('./optimizer.js').then(m => m.runOptimization());
+  });
+
+  const rebalanceChk = document.getElementById('rebalancing');
+  const freqSel      = document.getElementById('rebalancing-frequency');
+  const defensiveChk = document.getElementById('include-defensive-assets');
+
+  store.setParams({
+    rebalance: rebalanceChk?.checked || false,
+    rebalanceFreq: freqSel?.value || 'quarterly',
+    defensive: defensiveChk?.checked || false
+  });
+
+  rebalanceChk?.addEventListener('change', e => {
+    store.setParams({ rebalance: e.target.checked });
+  });
+
+  freqSel?.addEventListener('change', e => {
+    store.setParams({ rebalanceFreq: e.target.value });
+  });
+
+  defensiveChk?.addEventListener('change', e => {
+    store.setParams({ defensive: e.target.checked });
   });
 });
 

--- a/js/optimizer.js
+++ b/js/optimizer.js
@@ -21,7 +21,7 @@ const metricShr = document.getElementById('metric-sharpe');
 export async function runOptimization () {
 
   /* 1. Verifica tickers seleccionados y descarga OHLC faltantes */
-  const { tickers, prices, rf } = store.state;
+  const { tickers, prices, rf, params } = store.state;
   const freq  = document.getElementById('data-frequency')?.value || 'daily';
   const range = document.getElementById('data-range')?.value || '5y';
   if (tickers.length < 2) {
@@ -46,6 +46,10 @@ export async function runOptimization () {
               aligned.map(b => covariance(a, b) * factor));   // matriz cov.
 
   const rfVal = rf?.value || 0;
+
+  // Configuraciones adicionales (rebalanceo, activos defensivos, etc.)
+  const { rebalance, rebalanceFreq, defensive } = params;
+  console.log('Params:', { rebalance, rebalanceFreq, defensive });
 
   /* 4. Monte-Carlo -------------------------------------------------------- */
   const results = [];                                         // guarda KPIs

--- a/js/store.js
+++ b/js/store.js
@@ -12,8 +12,10 @@ const store = (() => {
     rf      : null,        // e.g. { date:'2025-06-01', value:0.0423 }
     max     : 12,          // tope visual para ui-tickers
     params  : {
-      maxWeight : 1,       // límite % por activo (1 → 100 %)
-      rebalance : false    // rebalanceo automático
+      maxWeight    : 1,          // límite % por activo (1 → 100 %)
+      rebalance    : false,      // rebalanceo automático
+      rebalanceFreq: 'quarterly',// "quarterly" | "annually"
+      defensive    : false       // incluir activos defensivos
     }
   };
 


### PR DESCRIPTION
## Summary
- track user selections for rebalancing and defensive options
- store new settings in the global store
- expose parameters to optimizer module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684633f9296c8320a3cc1a3630e9deab